### PR TITLE
Use properly unique range key for callouts and contributions

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -18,7 +18,7 @@ class Api(validApiKey: String, dynamo: Dynamo, formCreator: FormCreator) extends
         Future.successful(BadRequest("Invalid POST data"))
       }, { createCalloutData =>
         formCreator.createForm(createCalloutData.hashtag) map { formstackId =>
-          val callout = Callout(hashtag = createCalloutData.hashtag, description = createCalloutData.description, formstackId = Some(formstackId))
+          val callout = Callout.create(hashtag = createCalloutData.hashtag, description = createCalloutData.description, formstackId = Some(formstackId))
           dynamo.save(callout)
           Created
         }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -42,7 +42,7 @@ class Application(dynamo: Dynamo, formstackEmbedder: FormstackEmbedder, formCrea
       },
       calloutForm => {
         formCreator.createForm(calloutForm.hashtag) map { formstackId =>
-          val callout = Callout(hashtag = calloutForm.hashtag, description = calloutForm.description, formstackId = Some(formstackId))
+          val callout = Callout.create(hashtag = calloutForm.hashtag, description = calloutForm.description, formstackId = Some(formstackId))
           dynamo.save(callout)
           Redirect(routes.Application.showCalloutJustIn(calloutForm.hashtag)).flashing("info" -> "Successfully created a new callout!")
         }

--- a/app/formstack/FormstackWebhookHandler.scala
+++ b/app/formstack/FormstackWebhookHandler.scala
@@ -18,7 +18,7 @@ class FormstackWebhookHandler(ws: WSAPI, dynamo: Dynamo) {
       }
     }
     attachments map { a =>
-      val contribution = Contribution(
+      val contribution = Contribution.create(
         hashtag = hashtag,
         contributor = Contributor(email = payload.email, phone = None),
         channel = Channel.Form,

--- a/app/mailgun/MailgunWebhookHandler.scala
+++ b/app/mailgun/MailgunWebhookHandler.scala
@@ -22,7 +22,7 @@ class MailgunWebhookHandler(ws: WSAPI, mailgunApiKey: String, s3: S3, dynamo: Dy
     val fContribution = for {
       attachments <- copyAttachmentsToS3(validAttachments)
     } yield {
-      Contribution(
+      Contribution.create(
         hashtag = emailAddressToHashtag(payload.to),
         contributor = Contributor(email = Some(payload.from), phone = None),
         channel = Channel.Mail,

--- a/app/twilio/TwilioWebhookHandler.scala
+++ b/app/twilio/TwilioWebhookHandler.scala
@@ -8,7 +8,7 @@ import twilio.TwilioWebhookParser.Payload
 class TwilioWebhookHandler(dynamo: Dynamo) {
 
   def handlePayload(payload: Payload): Contribution = {
-    val contribution = Contribution(
+    val contribution = Contribution.create(
       hashtag = extractHashtag(payload),
       contributor = Contributor(email = None, phone = Some(payload.from)),
       channel = Channel.SMS,


### PR DESCRIPTION
Range keys are of the form "${createdAt}_${random uuid}", so they will be unique even if two items are created at the same time.

I was planning to make this change anyway, but my hand was forced because the PROD Dynamo tables were created with the range key names incorrectly set to `rangekey` in CloudFormation.